### PR TITLE
Fix sql statement in DNS Config module

### DIFF
--- a/modules/dns_admin/code/controller.ext.php
+++ b/modules/dns_admin/code/controller.ext.php
@@ -833,8 +833,8 @@ class module_controller {
 															dn_weight_in,
 															dn_port_in,
 															dn_created_ts) VALUES (
-															userID,
-															vh_name_vc,
+															:userID,
+															:vh_name_vc,
 															:domainID,
 															'A',
 															'mail',


### PR DESCRIPTION
Syntax error in a sql statement in CreateDefaultRecords method fixed. 
