### PR TITLE
Bug in Client Notice Manager with Greek characters

### DIFF
--- a/dryden/runtime/xss.class.php
+++ b/dryden/runtime/xss.class.php
@@ -137,13 +137,16 @@ class runtime_xss {
         if ($settings[5]) {
             $data = self::removeHarmfullStrings($data);
         }
-        if ($settings[6]) {
-            $data = self::htmlentitiesProtection($data, ENT_QUOTES, 'UTF-8');
-        }
         
         //Below is enforced protection
         $data = self::htmlspecialcharsProtection($data);
         
+        // This must follow the htmlspecialcharsProtection in order to avoid
+        // problems like A converted to &alpha; and then to &amp;alpha;
+        if ($settings[6]) {
+            $data = self::htmlentitiesProtection($data, ENT_QUOTES, 'UTF-8');
+        }
+
         if ($settings[0]) {
             $data = self::fixEntitys($data);
         }


### PR DESCRIPTION
Greek characters problem in Client Notice Manager fix : If the special characters protection follows the html entities protection then some greek characters like A are first translated into &alpha; and then into &amp;alpha; which breaks the content.
