### PR TITLE
Xss encoding, encoded information

### DIFF
--- a/dryden/runtime/xss.class.php
+++ b/dryden/runtime/xss.class.php
@@ -105,8 +105,8 @@ class runtime_xss {
      * @param string $type Type of encoding to use
      * @return string The Clean String.
      */
-    static public function htmlspecialcharsProtection($data='', $ENT = ENT_QUOTES, $type = 'UTF-8') {
-        $data = htmlspecialchars($data, $ENT, $type);
+    static public function htmlspecialcharsProtection($data='', $ENT = ENT_QUOTES, $type = 'UTF-8', $doubleEncoding = false) {
+        $data = htmlspecialchars($data, $ENT, $type, $doubleEncoding);
         return $data;
     }
 


### PR DESCRIPTION
QA TEAM TEST! This should stop the encoding of the already encoded html entities.

I currently don't have a ZPX set up so can not test this but reading PHP documentation (http://php.net/manual/en/function.htmlspecialchars.php) it should work fine.

If some one could update there server and email me login details i shall test this.

This needs testing that "Chers clients, vous êtes invités à" display correctly in inputs.
Also checking that it escape all Xss attempts! **Quick** test just past the below in a text box and check that no JS alerts are shown.

';alert(String.fromCharCode(88,83,83))//';alert(String.fromCharCode(88,83,83))//";
alert(String.fromCharCode(88,83,83))//";alert(String.fromCharCode(88,83,83))//--

> </SCRIPT>">'><SCRIPT>alert(String.fromCharCode(88,83,83))</SCRIPT>

Related Bug: http://bugs.zpanelcp.com/view.php?id=571
