### PR TITLE
Fixed Bug #595 (bugs.zpanelcp.com/view.php?id=595) Module pages use a different icon

### DIFF
--- a/modules/aliases/code/controller.ext.php
+++ b/modules/aliases/code/controller.ext.php
@@ -3,7 +3,7 @@
 /**
  *
  * ZPanel - A Cross-Platform Open-Source Web Hosting Control panel.
- * 
+ *
  * @package ZPanel
  * @version $Id$
  * @author Bobby Allen - ballen@zpanelcp.com
@@ -382,7 +382,13 @@ class module_controller {
 
     static function getModuleIcon() {
         global $controller;
-        $module_icon = "modules/" . $controller->GetControllerRequest('URL', 'module') . "/assets/icon.png";
+        $mod_folder = $controller->GetControllerRequest('URL', 'module');
+        // Check is Userland Theme has a Module Icon Override
+        if (file_exists('etc/styles/' . ui_template::GetUserTemplate() . '/images/'.$mod_folder.'/assets/icon.png')) {
+            $module_icon = 'etc/styles/' . ui_template::GetUserTemplate() . '/images/'.$mod_folder.'/assets/icon.png';
+        } else {
+            $module_icon = 'modules/' . $mod_folder . '/assets/icon.png';
+        }
         return $module_icon;
     }
 

--- a/modules/apache_admin/code/controller.ext.php
+++ b/modules/apache_admin/code/controller.ext.php
@@ -385,10 +385,15 @@ class module_controller
         return $module_name;
     }
 
-    static function getModuleIcon()
-    {
+    static function getModuleIcon() {
         global $controller;
-        $module_icon = "./modules/" . $controller->GetControllerRequest('URL', 'module') . "/assets/icon.png";
+        $mod_folder = $controller->GetControllerRequest('URL', 'module');
+        // Check is Userland Theme has a Module Icon Override
+        if (file_exists('etc/styles/' . ui_template::GetUserTemplate() . '/images/'.$mod_folder.'/assets/icon.png')) {
+            $module_icon = 'etc/styles/' . ui_template::GetUserTemplate() . '/images/'.$mod_folder.'/assets/icon.png';
+        } else {
+            $module_icon = 'modules/' . $mod_folder . '/assets/icon.png';
+        }
         return $module_icon;
     }
 

--- a/modules/backup_admin/code/controller.ext.php
+++ b/modules/backup_admin/code/controller.ext.php
@@ -3,7 +3,7 @@
 /**
  *
  * ZPanel - A Cross-Platform Open-Source Web Hosting Control panel.
- * 
+ *
  * @package ZPanel
  * @version $Id$
  * @author Bobby Allen - ballen@zpanelcp.com
@@ -32,12 +32,12 @@ class module_controller {
         global $zdbh;
         $currentuser = ctrl_users::GetUserDetail();
         $moduleName = ui_module::GetModuleName();
-        
+
         $sql = "SELECT * FROM x_settings WHERE so_module_vc=:module AND so_usereditable_en = 'true' ORDER BY so_cleanname_vc";
         $numrows = $zdbh->prepare($sql);
         $numrows->bindParam(':module', $moduleName);
         $numrows->execute();
-        
+
         //$numrows = $zdbh->query($sql);
         if ($numrows->fetchColumn() <> 0) {
             $sql = $zdbh->prepare($sql);
@@ -112,7 +112,13 @@ class module_controller {
 
     static function getModuleIcon() {
         global $controller;
-        $module_icon = "./modules/" . $controller->GetControllerRequest('URL', 'module') . "/assets/icon.png";
+        $mod_folder = $controller->GetControllerRequest('URL', 'module');
+        // Check is Userland Theme has a Module Icon Override
+        if (file_exists('etc/styles/' . ui_template::GetUserTemplate() . '/images/'.$mod_folder.'/assets/icon.png')) {
+            $module_icon = 'etc/styles/' . ui_template::GetUserTemplate() . '/images/'.$mod_folder.'/assets/icon.png';
+        } else {
+            $module_icon = 'modules/' . $mod_folder . '/assets/icon.png';
+        }
         return $module_icon;
     }
 

--- a/modules/backupmgr/code/controller.ext.php
+++ b/modules/backupmgr/code/controller.ext.php
@@ -3,7 +3,7 @@
 /**
  *
  * ZPanel - A Cross-Platform Open-Source Web Hosting Control panel.
- * 
+ *
  * @package ZPanel
  * @version $Id$
  * @author Bobby Allen - ballen@zpanelcp.com
@@ -223,7 +223,13 @@ class module_controller {
 
     static function getModuleIcon() {
         global $controller;
-        $module_icon = "modules/" . $controller->GetControllerRequest('URL', 'module') . "/assets/icon.png";
+        $mod_folder = $controller->GetControllerRequest('URL', 'module');
+        // Check is Userland Theme has a Module Icon Override
+        if (file_exists('etc/styles/' . ui_template::GetUserTemplate() . '/images/'.$mod_folder.'/assets/icon.png')) {
+            $module_icon = 'etc/styles/' . ui_template::GetUserTemplate() . '/images/'.$mod_folder.'/assets/icon.png';
+        } else {
+            $module_icon = 'modules/' . $mod_folder . '/assets/icon.png';
+        }
         return $module_icon;
     }
 

--- a/modules/client_notices/code/controller.ext.php
+++ b/modules/client_notices/code/controller.ext.php
@@ -3,7 +3,7 @@
 /**
  *
  * ZPanel - A Cross-Platform Open-Source Web Hosting Control panel.
- * 
+ *
  * @package ZPanel
  * @version $Id$
  * @author Bobby Allen - ballen@zpanelcp.com
@@ -33,7 +33,13 @@ class module_controller {
 
     static function getModuleIcon() {
         global $controller;
-        $module_icon = "modules/" . $controller->GetControllerRequest('URL', 'module') . "/assets/icon.png";
+        $mod_folder = $controller->GetControllerRequest('URL', 'module');
+        // Check is Userland Theme has a Module Icon Override
+        if (file_exists('etc/styles/' . ui_template::GetUserTemplate() . '/images/'.$mod_folder.'/assets/icon.png')) {
+            $module_icon = 'etc/styles/' . ui_template::GetUserTemplate() . '/images/'.$mod_folder.'/assets/icon.png';
+        } else {
+            $module_icon = 'modules/' . $mod_folder . '/assets/icon.png';
+        }
         return $module_icon;
     }
 
@@ -59,7 +65,7 @@ class module_controller {
         $sql->bindParam(':rid', $rid);
         $sql->execute();
         $result = $sql->fetch();
-        
+
         if ($result) {
             return runtime_xss::xssClean($result['ac_notice_tx']);
         } else {
@@ -89,7 +95,7 @@ class module_controller {
         header("location: ./?module=" . $controller->GetCurrentModule() . "&saved=true");
         exit;
     }
-    
+
     static function getCSFR_Tag() {
         return runtime_csfr::Token();
     }

--- a/modules/cron/code/controller.ext.php
+++ b/modules/cron/code/controller.ext.php
@@ -392,10 +392,15 @@ class module_controller
         return $module_name;
     }
 
-    static function getModuleIcon()
-    {
+    static function getModuleIcon() {
         global $controller;
-        $module_icon = "modules/" . $controller->GetControllerRequest('URL', 'module') . "/assets/icon.png";
+        $mod_folder = $controller->GetControllerRequest('URL', 'module');
+        // Check is Userland Theme has a Module Icon Override
+        if (file_exists('etc/styles/' . ui_template::GetUserTemplate() . '/images/'.$mod_folder.'/assets/icon.png')) {
+            $module_icon = 'etc/styles/' . ui_template::GetUserTemplate() . '/images/'.$mod_folder.'/assets/icon.png';
+        } else {
+            $module_icon = 'modules/' . $mod_folder . '/assets/icon.png';
+        }
         return $module_icon;
     }
 

--- a/modules/distlists/code/controller.ext.php
+++ b/modules/distlists/code/controller.ext.php
@@ -537,7 +537,14 @@ class module_controller {
 
     static function getModuleIcon() {
         global $controller;
-        return 'modules/' . $controller->GetControllerRequest('URL', 'module') . '/assets/icon.png';
+        $mod_folder = $controller->GetControllerRequest('URL', 'module');
+        // Check is Userland Theme has a Module Icon Override
+        if (file_exists('etc/styles/' . ui_template::GetUserTemplate() . '/images/'.$mod_folder.'/assets/icon.png')) {
+            $module_icon = 'etc/styles/' . ui_template::GetUserTemplate() . '/images/'.$mod_folder.'/assets/icon.png';
+        } else {
+            $module_icon = 'modules/' . $mod_folder . '/assets/icon.png';
+        }
+        return $module_icon;
     }
 
     static function getModuleDesc() {

--- a/modules/dns_admin/code/controller.ext.php
+++ b/modules/dns_admin/code/controller.ext.php
@@ -401,7 +401,7 @@ class module_controller
         else {
             $out = ctrl_system::systemCommand( ctrl_options::GetSystemOption( 'zsudo' ), array( 'service', ctrl_options::GetSystemOption( 'bind_service' ), 'reload' ) );
         }
-        
+
     }
 
     static function ResetAll()
@@ -1118,10 +1118,15 @@ class module_controller
         return $module_name;
     }
 
-    static function getModuleIcon()
-    {
+    static function getModuleIcon() {
         global $controller;
-        $module_icon = "./modules/" . $controller->GetControllerRequest( 'URL', 'module' ) . "/assets/icon.png";
+        $mod_folder = $controller->GetControllerRequest('URL', 'module');
+        // Check is Userland Theme has a Module Icon Override
+        if (file_exists('etc/styles/' . ui_template::GetUserTemplate() . '/images/'.$mod_folder.'/assets/icon.png')) {
+            $module_icon = 'etc/styles/' . ui_template::GetUserTemplate() . '/images/'.$mod_folder.'/assets/icon.png';
+        } else {
+            $module_icon = 'modules/' . $mod_folder . '/assets/icon.png';
+        }
         return $module_icon;
     }
 

--- a/modules/domains/code/controller.ext.php
+++ b/modules/domains/code/controller.ext.php
@@ -401,7 +401,14 @@ class module_controller {
 
     static function getModuleIcon() {
         global $controller;
-        return '/modules/' . $controller->GetControllerRequest('URL', 'module') . '/assets/icon.png';
+        $mod_folder = $controller->GetControllerRequest('URL', 'module');
+        // Check is Userland Theme has a Module Icon Override
+        if (file_exists('etc/styles/' . ui_template::GetUserTemplate() . '/images/'.$mod_folder.'/assets/icon.png')) {
+            $module_icon = 'etc/styles/' . ui_template::GetUserTemplate() . '/images/'.$mod_folder.'/assets/icon.png';
+        } else {
+            $module_icon = 'modules/' . $mod_folder . '/assets/icon.png';
+        }
+        return $module_icon;
     }
 
     static function getModuleDesc() {

--- a/modules/faqs/code/controller.ext.php
+++ b/modules/faqs/code/controller.ext.php
@@ -3,7 +3,7 @@
 /**
  *
  * ZPanel - A Cross-Platform Open-Source Web Hosting Control panel.
- * 
+ *
  * @package ZPanel
  * @version $Id$
  * @author Bobby Allen - ballen@zpanelcp.com
@@ -129,7 +129,13 @@ class module_controller {
 
     static function getModuleIcon() {
         global $controller;
-        $module_icon = "modules/" . $controller->GetControllerRequest('URL', 'module') . "/assets/icon.png";
+        $mod_folder = $controller->GetControllerRequest('URL', 'module');
+        // Check is Userland Theme has a Module Icon Override
+        if (file_exists('etc/styles/' . ui_template::GetUserTemplate() . '/images/'.$mod_folder.'/assets/icon.png')) {
+            $module_icon = 'etc/styles/' . ui_template::GetUserTemplate() . '/images/'.$mod_folder.'/assets/icon.png';
+        } else {
+            $module_icon = 'modules/' . $mod_folder . '/assets/icon.png';
+        }
         return $module_icon;
     }
 

--- a/modules/forwarders/code/controller.ext.php
+++ b/modules/forwarders/code/controller.ext.php
@@ -3,7 +3,7 @@
 /**
  *
  * ZPanel - A Cross-Platform Open-Source Web Hosting Control panel.
- * 
+ *
  * @package ZPanel
  * @version $Id$
  * @author Bobby Allen - ballen@zpanelcp.com
@@ -307,7 +307,7 @@ class module_controller {
             $used = ctrl_users::GetQuotaUsages('forwarders', $currentuser['userid']);
             $free = max($maximum - $used, 0);
             return  '<img src="etc/lib/pChart2/zpanel/z3DPie.php?score=' . $free . '::' . $used
-                  . '&labels=Free: ' . $free . '::Used: ' . $used 
+                  . '&labels=Free: ' . $free . '::Used: ' . $used
                   . '&legendfont=verdana&legendfontsize=8&imagesize=240::190&chartsize=120::90&radius=100&legendsize=150::160"'
                   . ' alt="'.ui_language::translate('Pie chart').'"/>';
         }
@@ -319,7 +319,14 @@ class module_controller {
 
     static function getModuleIcon() {
         global $controller;
-        return "modules/" . $controller->GetControllerRequest('URL', 'module') . "/assets/icon.png";
+        $mod_folder = $controller->GetControllerRequest('URL', 'module');
+        // Check is Userland Theme has a Module Icon Override
+        if (file_exists('etc/styles/' . ui_template::GetUserTemplate() . '/images/'.$mod_folder.'/assets/icon.png')) {
+            $module_icon = 'etc/styles/' . ui_template::GetUserTemplate() . '/images/'.$mod_folder.'/assets/icon.png';
+        } else {
+            $module_icon = 'modules/' . $mod_folder . '/assets/icon.png';
+        }
+        return $module_icon;
     }
 
     static function getModuleDesc() {

--- a/modules/ftp_admin/code/controller.ext.php
+++ b/modules/ftp_admin/code/controller.ext.php
@@ -3,7 +3,7 @@
 /**
  *
  * ZPanel - A Cross-Platform Open-Source Web Hosting Control panel.
- * 
+ *
  * @package ZPanel
  * @version $Id$
  * @author Bobby Allen - ballen@zpanelcp.com
@@ -106,10 +106,16 @@ class module_controller {
 
     static function getModuleIcon() {
         global $controller;
-        $module_icon = "./modules/" . $controller->GetControllerRequest('URL', 'module') . "/assets/icon.png";
+        $mod_folder = $controller->GetControllerRequest('URL', 'module');
+        // Check is Userland Theme has a Module Icon Override
+        if (file_exists('etc/styles/' . ui_template::GetUserTemplate() . '/images/'.$mod_folder.'/assets/icon.png')) {
+            $module_icon = 'etc/styles/' . ui_template::GetUserTemplate() . '/images/'.$mod_folder.'/assets/icon.png';
+        } else {
+            $module_icon = 'modules/' . $mod_folder . '/assets/icon.png';
+        }
         return $module_icon;
     }
-    
+
     static function getCSFR_Tag() {
         return runtime_csfr::Token();
     }

--- a/modules/ftp_management/code/controller.ext.php
+++ b/modules/ftp_management/code/controller.ext.php
@@ -413,7 +413,14 @@ class module_controller {
 
     static function getModuleIcon() {
         global $controller;
-        return 'modules/' . $controller->GetControllerRequest('URL', 'module') . '/assets/icon.png';
+        $mod_folder = $controller->GetControllerRequest('URL', 'module');
+        // Check is Userland Theme has a Module Icon Override
+        if (file_exists('etc/styles/' . ui_template::GetUserTemplate() . '/images/'.$mod_folder.'/assets/icon.png')) {
+            $module_icon = 'etc/styles/' . ui_template::GetUserTemplate() . '/images/'.$mod_folder.'/assets/icon.png';
+        } else {
+            $module_icon = 'modules/' . $mod_folder . '/assets/icon.png';
+        }
+        return $module_icon;
     }
 
     static function getModulePath() {

--- a/modules/mail_admin/code/controller.ext.php
+++ b/modules/mail_admin/code/controller.ext.php
@@ -3,7 +3,7 @@
 /**
  *
  * ZPanel - A Cross-Platform Open-Source Web Hosting Control panel.
- * 
+ *
  * @package ZPanel
  * @version $Id$
  * @author Bobby Allen - ballen@zpanelcp.com
@@ -106,7 +106,13 @@ class module_controller {
 
     static function getModuleIcon() {
         global $controller;
-        $module_icon = "./modules/" . $controller->GetControllerRequest('URL', 'module') . "/assets/icon.png";
+        $mod_folder = $controller->GetControllerRequest('URL', 'module');
+        // Check is Userland Theme has a Module Icon Override
+        if (file_exists('etc/styles/' . ui_template::GetUserTemplate() . '/images/'.$mod_folder.'/assets/icon.png')) {
+            $module_icon = 'etc/styles/' . ui_template::GetUserTemplate() . '/images/'.$mod_folder.'/assets/icon.png';
+        } else {
+            $module_icon = 'modules/' . $mod_folder . '/assets/icon.png';
+        }
         return $module_icon;
     }
 

--- a/modules/mailboxes/code/controller.ext.php
+++ b/modules/mailboxes/code/controller.ext.php
@@ -403,7 +403,14 @@ class module_controller {
 
     static function getModuleIcon() {
         global $controller;
-        return 'modules/' . $controller->GetControllerRequest('URL', 'module') . '/assets/icon.png';
+        $mod_folder = $controller->GetControllerRequest('URL', 'module');
+        // Check is Userland Theme has a Module Icon Override
+        if (file_exists('etc/styles/' . ui_template::GetUserTemplate() . '/images/'.$mod_folder.'/assets/icon.png')) {
+            $module_icon = 'etc/styles/' . ui_template::GetUserTemplate() . '/images/'.$mod_folder.'/assets/icon.png';
+        } else {
+            $module_icon = 'modules/' . $mod_folder . '/assets/icon.png';
+        }
+        return $module_icon;
     }
 
     static function getModuleDesc() {

--- a/modules/manage_clients/code/controller.ext.php
+++ b/modules/manage_clients/code/controller.ext.php
@@ -3,7 +3,7 @@
 /**
  *
  * ZPanel - A Cross-Platform Open-Source Web Hosting Control panel.
- * 
+ *
  * @package ZPanel
  * @version $Id$
  * @author Bobby Allen - ballen@zpanelcp.com
@@ -311,7 +311,7 @@ class module_controller {
         global $zdbh;
         runtime_hook::Execute('OnBeforeSetClientAccount');
         $sql = $zdbh->prepare("UPDATE x_accounts
-								SET :column=:value 
+								SET :column=:value
 								WHERE ac_id_pk=:userid");
         $sql->bindParam(':column', $column);
         $sql->bindParam(':value', $value);
@@ -338,29 +338,29 @@ class module_controller {
         runtime_hook::Execute('OnBeforeDeleteClient');
         $sql = $zdbh->prepare("
 			UPDATE x_accounts
-			SET ac_deleted_ts=:time 
+			SET ac_deleted_ts=:time
 			WHERE ac_id_pk=:userid");
         $time = time();
         $sql->bindParam(':time', $time);
         $sql->bindParam(':userid', $userid);
         $sql->execute();
         $sql = $zdbh->prepare("
-			UPDATE x_accounts 
+			UPDATE x_accounts
 			SET ac_reseller_fk = :moveid
 			WHERE ac_reseller_fk = :userid");
         $sql->bindParam(':moveid', $moveid);
         $sql->bindParam(':userid', $userid);
         $sql->execute();
         $sql = $zdbh->prepare("
-			UPDATE x_packages 
-			SET pk_reseller_fk = :moveid 
+			UPDATE x_packages
+			SET pk_reseller_fk = :moveid
 			WHERE pk_reseller_fk = :userid");
         $sql->bindParam(':moveid', $moveid);
         $sql->bindParam(':userid', $userid);
         $sql->execute();
         $sql = $zdbh->prepare("
-			UPDATE x_groups 
-			SET ug_reseller_fk = :moveid 
+			UPDATE x_groups
+			SET ug_reseller_fk = :moveid
 			WHERE ug_reseller_fk = :userid");
         $sql->bindParam(':moveid', $moveid);
         $sql->bindParam(':userid', $userid);
@@ -533,7 +533,7 @@ class module_controller {
         fs_director::SetFileSystemPermissions(ctrl_options::GetSystemOption('hosted_dir') . $username . "/public_html", 0777);
         fs_director::CreateDirectory(ctrl_options::GetSystemOption('hosted_dir') . $username . "/backups");
         fs_director::SetFileSystemPermissions(ctrl_options::GetSystemOption('hosted_dir') . $username . "/backups", 0777);
-        // Send the user account details via. email (if requested)... 
+        // Send the user account details via. email (if requested)...
         if ($sendemail <> 0) {
             if (isset($_SERVER['HTTPS'])) {
                 $protocol = 'https://';
@@ -632,7 +632,7 @@ class module_controller {
                 return true;
             } else {
                 self::$not_unique_email = true;
-                return false; 
+                return false;
             }
         } else {
             self::$not_unique_email = true;
@@ -671,18 +671,18 @@ class module_controller {
         $line = ui_language::translate("Hi {{fullname}},\r\rWe are pleased to inform you that your new hosting account is now active!\r\rYou can access your web hosting control panel using this link:\r{{controlpanelurl}}\r\rYour username and password is as follows:\rUsername: {{username}}\rPassword: {{password}}\r\rMany thanks,\rThe management");
         return $line;
     }
-    
+
     /**
      * Checks if the user already exists in the x_accounts table.
      * @global type $zdbh The ZPanelX database handle.
      * @param type $username The username to check against.
      * @return boolean
      */
-    static function CheckUserExits($username){ 
+    static function CheckUserExits($username){
         global $zdbh;
             $sql = "SELECT COUNT(*) FROM x_accounts WHERE LOWER(ac_user_vc)=:username";
             $uniqueuser = $zdbh->prepare($sql);
-            $uniqueuser->bindParam(':username', strtolower($username));       
+            $uniqueuser->bindParam(':username', strtolower($username));
             if ($uniqueuser->execute()) {
                 if ($uniqueuser->fetchColumn() > 0) {
                     return true;
@@ -691,7 +691,7 @@ class module_controller {
                 }
             } else {
                 return true;
-            }        
+            }
     }
 
     /**
@@ -1020,7 +1020,13 @@ class module_controller {
 
     static function getModuleIcon() {
         global $controller;
-        $module_icon = "modules/" . $controller->GetControllerRequest('URL', 'module') . "/assets/icon.png";
+        $mod_folder = $controller->GetControllerRequest('URL', 'module');
+        // Check is Userland Theme has a Module Icon Override
+        if (file_exists('etc/styles/' . ui_template::GetUserTemplate() . '/images/'.$mod_folder.'/assets/icon.png')) {
+            $module_icon = 'etc/styles/' . ui_template::GetUserTemplate() . '/images/'.$mod_folder.'/assets/icon.png';
+        } else {
+            $module_icon = 'modules/' . $mod_folder . '/assets/icon.png';
+        }
         return $module_icon;
     }
 

--- a/modules/manage_groups/code/controller.ext.php
+++ b/modules/manage_groups/code/controller.ext.php
@@ -3,7 +3,7 @@
 /**
  *
  * ZPanel - A Cross-Platform Open-Source Web Hosting Control panel.
- * 
+ *
  * @package ZPanel
  * @version $Id$
  * @author Bobby Allen - ballen@zpanelcp.com
@@ -33,7 +33,13 @@ class module_controller {
 
     static function getModuleIcon() {
         global $controller;
-        $module_icon = "modules/" . $controller->GetControllerRequest('URL', 'module') . "/assets/icon.png";
+        $mod_folder = $controller->GetControllerRequest('URL', 'module');
+        // Check is Userland Theme has a Module Icon Override
+        if (file_exists('etc/styles/' . ui_template::GetUserTemplate() . '/images/'.$mod_folder.'/assets/icon.png')) {
+            $module_icon = 'etc/styles/' . ui_template::GetUserTemplate() . '/images/'.$mod_folder.'/assets/icon.png';
+        } else {
+            $module_icon = 'modules/' . $mod_folder . '/assets/icon.png';
+        }
         return $module_icon;
     }
 

--- a/modules/moduleadmin/code/controller.ext.php
+++ b/modules/moduleadmin/code/controller.ext.php
@@ -391,7 +391,13 @@ class module_controller {
 
     static function getModuleIcon() {
         global $controller;
-        $module_icon = "modules/" . $controller->GetControllerRequest('URL', 'module') . "/assets/icon.png";
+        $mod_folder = $controller->GetControllerRequest('URL', 'module');
+        // Check is Userland Theme has a Module Icon Override
+        if (file_exists('etc/styles/' . ui_template::GetUserTemplate() . '/images/'.$mod_folder.'/assets/icon.png')) {
+            $module_icon = 'etc/styles/' . ui_template::GetUserTemplate() . '/images/'.$mod_folder.'/assets/icon.png';
+        } else {
+            $module_icon = 'modules/' . $mod_folder . '/assets/icon.png';
+        }
         return $module_icon;
     }
 

--- a/modules/my_account/code/controller.ext.php
+++ b/modules/my_account/code/controller.ext.php
@@ -3,7 +3,7 @@
 /**
  *
  * ZPanel - A Cross-Platform Open-Source Web Hosting Control panel.
- * 
+ *
  * @package ZPanel
  * @version $Id$
  * @author Bobby Allen - ballen@zpanelcp.com
@@ -147,7 +147,13 @@ class module_controller {
 
     static function getModuleIcon() {
         global $controller;
-        $module_icon = "modules/" . $controller->GetControllerRequest('URL', 'module') . "/assets/icon.png";
+        $mod_folder = $controller->GetControllerRequest('URL', 'module');
+        // Check is Userland Theme has a Module Icon Override
+        if (file_exists('etc/styles/' . ui_template::GetUserTemplate() . '/images/'.$mod_folder.'/assets/icon.png')) {
+            $module_icon = 'etc/styles/' . ui_template::GetUserTemplate() . '/images/'.$mod_folder.'/assets/icon.png';
+        } else {
+            $module_icon = 'modules/' . $mod_folder . '/assets/icon.png';
+        }
         return $module_icon;
     }
 

--- a/modules/mysql_databases/code/controller.ext.php
+++ b/modules/mysql_databases/code/controller.ext.php
@@ -316,7 +316,14 @@ class module_controller {
 
     static function getModuleIcon() {
         global $controller;
-        return "modules/" . $controller->GetControllerRequest('URL', 'module') . "/assets/icon.png";
+        $mod_folder = $controller->GetControllerRequest('URL', 'module');
+        // Check is Userland Theme has a Module Icon Override
+        if (file_exists('etc/styles/' . ui_template::GetUserTemplate() . '/images/'.$mod_folder.'/assets/icon.png')) {
+            $module_icon = 'etc/styles/' . ui_template::GetUserTemplate() . '/images/'.$mod_folder.'/assets/icon.png';
+        } else {
+            $module_icon = 'modules/' . $mod_folder . '/assets/icon.png';
+        }
+        return $module_icon;
     }
 
     /**

--- a/modules/mysql_users/code/controller.ext.php
+++ b/modules/mysql_users/code/controller.ext.php
@@ -3,7 +3,7 @@
 /**
  *
  * ZPanel - A Cross-Platform Open-Source Web Hosting Control panel.
- * 
+ *
  * @package ZPanel
  * @version $Id$
  * @author Bobby Allen - ballen@zpanelcp.com
@@ -57,7 +57,7 @@ class module_controller {
                 $rowdb = $find->fetch();
 
                 if (!$rowdb) {
-                    
+
                 }
             }
             return true;
@@ -352,7 +352,7 @@ class module_controller {
         }
         $sql = $zdbh->prepare("
 			UPDATE x_mysql_users
-			SET mu_deleted_ts = :time 
+			SET mu_deleted_ts = :time
 			WHERE mu_id_pk = :mu_id_pk");
         $time = time();
         $sql->bindParam(':time', $time);
@@ -389,7 +389,7 @@ class module_controller {
         $numrows->bindParam(':myuserid', $myuserid);
         $numrows->execute();
         $rowuser = $numrows->fetch();
-        
+
         $my_name_vc = $zdbh->mysqlRealEscapeString($rowdb['my_name_vc']);
         $mu_name_vc = $zdbh->mysqlRealEscapeString($rowuser['mu_name_vc']);
         $mu_access_vc = $zdbh->mysqlRealEscapeString($rowuser['mu_access_vc']);
@@ -421,17 +421,17 @@ class module_controller {
     static function ExecuteRemoveDB($myuserid, $mapid) { // <-- mmid = dbmaps
         global $zdbh;
         runtime_hook::Execute('OnBeforeRemoveDatabaseAccess');
-     
+
         $numrows = $zdbh->prepare("SELECT * FROM x_mysql_dbmap WHERE mm_id_pk=:mapid");
         $numrows->bindParam(':mapid', $mapid);
         $numrows->execute();
         $rowdbmap = $numrows->fetch();
-     
+
         $numrows = $zdbh->prepare("SELECT * FROM x_mysql_databases WHERE my_id_pk=:mm_database_fk AND my_deleted_ts IS NULL");
         $numrows->bindParam(':mm_database_fk', $rowdbmap['mm_database_fk']);
         $numrows->execute();
         $rowdb = $numrows->fetch();
-       
+
         $numrows = $zdbh->prepare("SELECT * FROM x_mysql_users WHERE mu_id_pk=:myuserid AND mu_deleted_ts IS NULL");
         $numrows->bindParam(':myuserid', $myuserid);
         $numrows->execute();
@@ -439,7 +439,7 @@ class module_controller {
 
         $sql = $zdbh->prepare("REVOKE ALL PRIVILEGES ON `" . $rowdb['my_name_vc'] . "`.* FROM '" . $rowuser['mu_name_vc'] . "'@'" . $rowuser['mu_access_vc'] . "'");
         $sql->execute();
-        
+
         $sql = $zdbh->prepare("FLUSH PRIVILEGES");
         $sql->execute();
 
@@ -456,7 +456,7 @@ class module_controller {
     static function ExecuteResetPassword($myuserid, $password) {
         global $zdbh;
         runtime_hook::Execute('OnBeforeResetDatabasePassword');
-        //$rowuser = $zdbh->query("SELECT * FROM x_mysql_users WHERE mu_id_pk=" . $myuserid . " AND mu_deleted_ts IS NULL")->fetch();        
+        //$rowuser = $zdbh->query("SELECT * FROM x_mysql_users WHERE mu_id_pk=" . $myuserid . " AND mu_deleted_ts IS NULL")->fetch();
         $numrows = $zdbh->prepare("SELECT * FROM x_mysql_users WHERE mu_id_pk=:myuserid AND mu_deleted_ts IS NULL");
         $numrows->bindParam(':myuserid', $myuserid);
         $numrows->execute();
@@ -727,7 +727,13 @@ class module_controller {
 
     static function getModuleIcon() {
         global $controller;
-        $module_icon = "modules/" . $controller->GetControllerRequest('URL', 'module') . "/assets/icon.png";
+        $mod_folder = $controller->GetControllerRequest('URL', 'module');
+        // Check is Userland Theme has a Module Icon Override
+        if (file_exists('etc/styles/' . ui_template::GetUserTemplate() . '/images/'.$mod_folder.'/assets/icon.png')) {
+            $module_icon = 'etc/styles/' . ui_template::GetUserTemplate() . '/images/'.$mod_folder.'/assets/icon.png';
+        } else {
+            $module_icon = 'modules/' . $mod_folder . '/assets/icon.png';
+        }
         return $module_icon;
     }
 

--- a/modules/news/code/controller.ext.php
+++ b/modules/news/code/controller.ext.php
@@ -3,7 +3,7 @@
 /**
  *
  * ZPanel - A Cross-Platform Open-Source Web Hosting Control panel.
- * 
+ *
  * @package ZPanel
  * @version $Id$
  * @author Bobby Allen - ballen@zpanelcp.com
@@ -41,7 +41,13 @@ class module_controller {
 
     static function getModuleIcon() {
         global $controller;
-        $module_icon = "modules/" . $controller->GetControllerRequest('URL', 'module') . "/assets/icon.png";
+        $mod_folder = $controller->GetControllerRequest('URL', 'module');
+        // Check is Userland Theme has a Module Icon Override
+        if (file_exists('etc/styles/' . ui_template::GetUserTemplate() . '/images/'.$mod_folder.'/assets/icon.png')) {
+            $module_icon = 'etc/styles/' . ui_template::GetUserTemplate() . '/images/'.$mod_folder.'/assets/icon.png';
+        } else {
+            $module_icon = 'modules/' . $mod_folder . '/assets/icon.png';
+        }
         return $module_icon;
     }
 

--- a/modules/packages/code/controller.ext.php
+++ b/modules/packages/code/controller.ext.php
@@ -3,7 +3,7 @@
 /**
  *
  * ZPanel - A Cross-Platform Open-Source Web Hosting Control panel.
- * 
+ *
  * @package ZPanel
  * @version $Id$
  * @author Bobby Allen - ballen@zpanelcp.com
@@ -68,8 +68,8 @@ class module_controller {
 
     static function ListCurrentPackage($id) {
         global $zdbh;
-        $sql = "SELECT * FROM x_packages 
-				LEFT JOIN x_quotas  ON (x_packages.pk_id_pk=x_quotas.qt_package_fk) 
+        $sql = "SELECT * FROM x_packages
+				LEFT JOIN x_quotas  ON (x_packages.pk_id_pk=x_quotas.qt_package_fk)
 				WHERE pk_id_pk=:id AND pk_deleted_ts IS NULL";
         //$numrows = $zdbh->query($sql);
         $numrows = $zdbh->prepare($sql);
@@ -141,8 +141,8 @@ class module_controller {
         $sql->bindParam(':pk_id_pk', $pk_id_pk);
         $sql->execute();
         $sql = $zdbh->prepare("
-			UPDATE x_packages 
-			SET pk_deleted_ts = :time 
+			UPDATE x_packages
+			SET pk_deleted_ts = :time
 			WHERE pk_id_pk = :pk_id_pk");
         $time = time();
         $sql->bindParam(':time', $time);
@@ -248,7 +248,7 @@ class module_controller {
         runtime_hook::Execute('OnBeforeUpdatePackage');
         $sql = $zdbh->prepare("UPDATE x_packages SET pk_name_vc=:packagename,
 								pk_enablephp_in = :php,
-								pk_enablecgi_in = :cgi 
+								pk_enablecgi_in = :cgi
 								WHERE pk_id_pk  = :pid");
 
         $php = fs_director::GetCheckboxValue($EnablePHP);
@@ -258,7 +258,7 @@ class module_controller {
         $sql->bindParam(':pid', $pid);
         $sql->bindParam(':packagename', $packagename);
         $sql->execute();
-        $sql = $zdbh->prepare("UPDATE x_quotas SET qt_domains_in = :Domains, 
+        $sql = $zdbh->prepare("UPDATE x_quotas SET qt_domains_in = :Domains,
 								qt_parkeddomains_in = :ParkedDomains,
 								qt_ftpaccounts_in   = :FTPAccounts,
 								qt_subdomains_in    = :SubDomains,
@@ -630,7 +630,13 @@ class module_controller {
 
     static function getModuleIcon() {
         global $controller;
-        $module_icon = "modules/" . $controller->GetControllerRequest('URL', 'module') . "/assets/icon.png";
+        $mod_folder = $controller->GetControllerRequest('URL', 'module');
+        // Check is Userland Theme has a Module Icon Override
+        if (file_exists('etc/styles/' . ui_template::GetUserTemplate() . '/images/'.$mod_folder.'/assets/icon.png')) {
+            $module_icon = 'etc/styles/' . ui_template::GetUserTemplate() . '/images/'.$mod_folder.'/assets/icon.png';
+        } else {
+            $module_icon = 'modules/' . $mod_folder . '/assets/icon.png';
+        }
         return $module_icon;
     }
 

--- a/modules/parked_domains/code/controller.ext.php
+++ b/modules/parked_domains/code/controller.ext.php
@@ -3,7 +3,7 @@
 /**
  *
  * ZPanel - A Cross-Platform Open-Source Web Hosting Control panel.
- * 
+ *
  * @package ZPanel
  * @version $Id$
  * @author Bobby Allen - ballen@zpanelcp.com
@@ -91,8 +91,8 @@ class module_controller {
     static function ExecuteDeleteParkedDomain($id) {
         global $zdbh;
         runtime_hook::Execute('OnBeforeDeleteParkedDomain');
-        $sql = $zdbh->prepare("UPDATE x_vhosts 
-							   SET vh_deleted_ts=:time 
+        $sql = $zdbh->prepare("UPDATE x_vhosts
+							   SET vh_deleted_ts=:time
 							   WHERE vh_id_pk=:id");
         $sql->bindParam(':id', $id);
         $time = time();
@@ -166,7 +166,7 @@ class module_controller {
         $sql = "SELECT COUNT(*) FROM x_vhosts WHERE vh_name_vc=:domain AND vh_deleted_ts IS NULL";
         $numrows = $zdbh->prepare($sql);
         $numrows->bindParam(':domain', $domain);
-        
+
         if ($numrows->execute()) {
             if ($numrows->fetchColumn() > 0) {
                 self::$alreadyexists = TRUE;
@@ -276,7 +276,7 @@ class module_controller {
 
     static function getCreateParkedDomain() {
         $currentuser = ctrl_users::GetUserDetail();
-        return ($currentuser['parkeddomainquota'] < 0) or //-1 = unlimited 
+        return ($currentuser['parkeddomainquota'] < 0) or //-1 = unlimited
                ($currentuser['parkeddomainquota'] > ctrl_users::GetQuotaUsages('parkeddomains', $currentuser['userid']));
     }
 
@@ -346,7 +346,14 @@ class module_controller {
 
     static function getModuleIcon() {
         global $controller;
-        return '/modules/' . $controller->GetControllerRequest('URL', 'module') . '/assets/icon.png';
+        $mod_folder = $controller->GetControllerRequest('URL', 'module');
+        // Check is Userland Theme has a Module Icon Override
+        if (file_exists('etc/styles/' . ui_template::GetUserTemplate() . '/images/'.$mod_folder.'/assets/icon.png')) {
+            $module_icon = 'etc/styles/' . ui_template::GetUserTemplate() . '/images/'.$mod_folder.'/assets/icon.png';
+        } else {
+            $module_icon = 'modules/' . $mod_folder . '/assets/icon.png';
+        }
+        return $module_icon;
     }
 
     static function getModuleDesc() {
@@ -362,7 +369,7 @@ class module_controller {
             $used = ctrl_users::GetQuotaUsages('parkeddomains', $currentuser['userid']);
             $free = max($maximum - $used, 0);
             return  '<img src="etc/lib/pChart2/zpanel/z3DPie.php?score=' . $free . '::' . $used
-                  . '&labels=Free: ' . $free . '::Used: ' . $used 
+                  . '&labels=Free: ' . $free . '::Used: ' . $used
                   . '&legendfont=verdana&legendfontsize=8&imagesize=240::190&chartsize=120::90&radius=100&legendsize=150::160"'
                   . ' alt="'.ui_language::translate('Pie chart').'/>';
         }

--- a/modules/password_assistant/code/controller.ext.php
+++ b/modules/password_assistant/code/controller.ext.php
@@ -3,7 +3,7 @@
 /**
  *
  * ZPanel - A Cross-Platform Open-Source Web Hosting Control panel.
- * 
+ *
  * @package ZPanel
  * @version $Id$
  * @author Bobby Allen - ballen@zpanelcp.com
@@ -106,7 +106,13 @@ class module_controller {
 
     static function getModuleIcon() {
         global $controller;
-        $module_icon = "modules/" . $controller->GetControllerRequest('URL', 'module') . "/assets/icon.png";
+        $mod_folder = $controller->GetControllerRequest('URL', 'module');
+        // Check is Userland Theme has a Module Icon Override
+        if (file_exists('etc/styles/' . ui_template::GetUserTemplate() . '/images/'.$mod_folder.'/assets/icon.png')) {
+            $module_icon = 'etc/styles/' . ui_template::GetUserTemplate() . '/images/'.$mod_folder.'/assets/icon.png';
+        } else {
+            $module_icon = 'modules/' . $mod_folder . '/assets/icon.png';
+        }
         return $module_icon;
     }
 

--- a/modules/phpinfo/code/controller.ext.php
+++ b/modules/phpinfo/code/controller.ext.php
@@ -48,7 +48,13 @@ class module_controller {
 
     static function getModuleIcon() {
         global $controller;
-        $module_icon = "modules/" . $controller->GetControllerRequest('URL', 'module') . "/assets/icon.png";
+        $mod_folder = $controller->GetControllerRequest('URL', 'module');
+        // Check is Userland Theme has a Module Icon Override
+        if (file_exists('etc/styles/' . ui_template::GetUserTemplate() . '/images/'.$mod_folder.'/assets/icon.png')) {
+            $module_icon = 'etc/styles/' . ui_template::GetUserTemplate() . '/images/'.$mod_folder.'/assets/icon.png';
+        } else {
+            $module_icon = 'modules/' . $mod_folder . '/assets/icon.png';
+        }
         return $module_icon;
     }
 

--- a/modules/phpmyadmin/code/controller.ext.php
+++ b/modules/phpmyadmin/code/controller.ext.php
@@ -3,7 +3,7 @@
 /**
  *
  * ZPanel - A Cross-Platform Open-Source Web Hosting Control panel.
- * 
+ *
  * @package ZPanel
  * @version $Id$
  * @author Bobby Allen - ballen@zpanelcp.com
@@ -33,7 +33,13 @@ class module_controller {
 
     static function getModuleIcon() {
         global $controller;
-        $module_icon = "modules/" . $controller->GetControllerRequest('URL', 'module') . "/assets/icon.png";
+        $mod_folder = $controller->GetControllerRequest('URL', 'module');
+        // Check is Userland Theme has a Module Icon Override
+        if (file_exists('etc/styles/' . ui_template::GetUserTemplate() . '/images/'.$mod_folder.'/assets/icon.png')) {
+            $module_icon = 'etc/styles/' . ui_template::GetUserTemplate() . '/images/'.$mod_folder.'/assets/icon.png';
+        } else {
+            $module_icon = 'modules/' . $mod_folder . '/assets/icon.png';
+        }
         return $module_icon;
     }
 

--- a/modules/phpsysinfo/code/controller.ext.php
+++ b/modules/phpsysinfo/code/controller.ext.php
@@ -3,7 +3,7 @@
 /**
  *
  * ZPanel - A Cross-Platform Open-Source Web Hosting Control panel.
- * 
+ *
  * @package ZPanel
  * @version $Id$
  * @author Bobby Allen - ballen@zpanelcp.com
@@ -38,7 +38,13 @@ class module_controller {
 
     static function getModuleIcon() {
         global $controller;
-        $module_icon = "modules/" . $controller->GetControllerRequest('URL', 'module') . "/assets/icon.png";
+        $mod_folder = $controller->GetControllerRequest('URL', 'module');
+        // Check is Userland Theme has a Module Icon Override
+        if (file_exists('etc/styles/' . ui_template::GetUserTemplate() . '/images/'.$mod_folder.'/assets/icon.png')) {
+            $module_icon = 'etc/styles/' . ui_template::GetUserTemplate() . '/images/'.$mod_folder.'/assets/icon.png';
+        } else {
+            $module_icon = 'modules/' . $mod_folder . '/assets/icon.png';
+        }
         return $module_icon;
     }
 

--- a/modules/services/code/controller.ext.php
+++ b/modules/services/code/controller.ext.php
@@ -3,7 +3,7 @@
 /**
  *
  * ZPanel - A Cross-Platform Open-Source Web Hosting Control panel.
- * 
+ *
  * @package ZPanel
  * @version $Id$
  * @author Bobby Allen - ballen@zpanelcp.com
@@ -128,7 +128,13 @@ class module_controller {
 
     static function getModuleIcon() {
         global $controller;
-        $module_icon = "modules/" . $controller->GetControllerRequest('URL', 'module') . "/assets/icon.png";
+        $mod_folder = $controller->GetControllerRequest('URL', 'module');
+        // Check is Userland Theme has a Module Icon Override
+        if (file_exists('etc/styles/' . ui_template::GetUserTemplate() . '/images/'.$mod_folder.'/assets/icon.png')) {
+            $module_icon = 'etc/styles/' . ui_template::GetUserTemplate() . '/images/'.$mod_folder.'/assets/icon.png';
+        } else {
+            $module_icon = 'modules/' . $mod_folder . '/assets/icon.png';
+        }
         return $module_icon;
     }
 

--- a/modules/shadowing/code/controller.ext.php
+++ b/modules/shadowing/code/controller.ext.php
@@ -3,7 +3,7 @@
 /**
  *
  * ZPanel - A Cross-Platform Open-Source Web Hosting Control panel.
- * 
+ *
  * @package ZPanel
  * @version $Id$
  * @author Bobby Allen - ballen@zpanelcp.com
@@ -35,12 +35,12 @@ class module_controller {
         if ($currentuser['username'] == 'zadmin') {
             $sql = "SELECT * FROM x_accounts WHERE ac_deleted_ts IS NULL ORDER BY ac_user_vc";
             $numrows = $zdbh->prepare($sql);
-            $numrows->execute();        
+            $numrows->execute();
         } else {
             $sql = "SELECT * FROM x_accounts WHERE ac_reseller_fk = :userid AND ac_deleted_ts IS NULL ORDER BY ac_user_vc";
             $numrows = $zdbh->prepare($sql);
             $numrows->bindParam(':userid', $currentuser['userid']);
-            $numrows->execute();        
+            $numrows->execute();
         }
 
         //$numrows = $zdbh->query($sql);
@@ -78,11 +78,11 @@ class module_controller {
         $currentuser = ctrl_users::GetUserDetail();
         if ($currentuser['username'] == 'zadmin') {
             $sql = "SELECT * FROM x_accounts WHERE ac_deleted_ts IS NULL ORDER BY ac_user_vc";
-            $numrows = $zdbh->prepare($sql);          
+            $numrows = $zdbh->prepare($sql);
         } else {
             $sql = "SELECT COUNT(*) FROM x_accounts WHERE ac_reseller_fk = :userid AND ac_deleted_ts IS NULL";
             $numrows = $zdbh->prepare($sql);
-            $numrows->bindParam(':userid', $currentuser['userid']);            
+            $numrows->bindParam(':userid', $currentuser['userid']);
         }
         if ($numrows->execute()) {
             if ($numrows->fetchColumn() <> 0) {
@@ -114,7 +114,13 @@ class module_controller {
 
     static function getModuleIcon() {
         global $controller;
-        $module_icon = "modules/" . $controller->GetControllerRequest('URL', 'module') . "/assets/icon.png";
+        $mod_folder = $controller->GetControllerRequest('URL', 'module');
+        // Check is Userland Theme has a Module Icon Override
+        if (file_exists('etc/styles/' . ui_template::GetUserTemplate() . '/images/'.$mod_folder.'/assets/icon.png')) {
+            $module_icon = 'etc/styles/' . ui_template::GetUserTemplate() . '/images/'.$mod_folder.'/assets/icon.png';
+        } else {
+            $module_icon = 'modules/' . $mod_folder . '/assets/icon.png';
+        }
         return $module_icon;
     }
 

--- a/modules/sub_domains/code/controller.ext.php
+++ b/modules/sub_domains/code/controller.ext.php
@@ -383,7 +383,14 @@ class module_controller {
 
     static function getModuleIcon() {
         global $controller;
-        return '/modules/' . $controller->GetControllerRequest('URL', 'module') . '/assets/icon.png';
+        $mod_folder = $controller->GetControllerRequest('URL', 'module');
+        // Check is Userland Theme has a Module Icon Override
+        if (file_exists('etc/styles/' . ui_template::GetUserTemplate() . '/images/'.$mod_folder.'/assets/icon.png')) {
+            $module_icon = 'etc/styles/' . ui_template::GetUserTemplate() . '/images/'.$mod_folder.'/assets/icon.png';
+        } else {
+            $module_icon = 'modules/' . $mod_folder . '/assets/icon.png';
+        }
+        return $module_icon;
     }
 
     static function getModuleDesc() {

--- a/modules/theme_manager/code/controller.ext.php
+++ b/modules/theme_manager/code/controller.ext.php
@@ -3,7 +3,7 @@
 /**
  *
  * ZPanel - A Cross-Platform Open-Source Web Hosting Control panel.
- * 
+ *
  * @package ZPanel
  * @version $Id$
  * @author Bobby Allen - ballen@zpanelcp.com
@@ -33,7 +33,13 @@ class module_controller {
 
     static function getModuleIcon() {
         global $controller;
-        $module_icon = "modules/" . $controller->GetControllerRequest('URL', 'module') . "/assets/icon.png";
+        $mod_folder = $controller->GetControllerRequest('URL', 'module');
+        // Check is Userland Theme has a Module Icon Override
+        if (file_exists('etc/styles/' . ui_template::GetUserTemplate() . '/images/'.$mod_folder.'/assets/icon.png')) {
+            $module_icon = 'etc/styles/' . ui_template::GetUserTemplate() . '/images/'.$mod_folder.'/assets/icon.png';
+        } else {
+            $module_icon = 'modules/' . $mod_folder . '/assets/icon.png';
+        }
         return $module_icon;
     }
 

--- a/modules/updates/code/controller.ext.php
+++ b/modules/updates/code/controller.ext.php
@@ -3,7 +3,7 @@
 /**
  *
  * ZPanel - A Cross-Platform Open-Source Web Hosting Control panel.
- * 
+ *
  * @package ZPanel
  * @version $Id$
  * @author Bobby Allen - ballen@zpanelcp.com
@@ -42,9 +42,15 @@ class module_controller {
         return $module_name;
     }
 
-    public static function getModuleIcon() {
+    static function getModuleIcon() {
         global $controller;
-        $module_icon = "modules/" . $controller->GetControllerRequest('URL', 'module') . "/assets/icon.png";
+        $mod_folder = $controller->GetControllerRequest('URL', 'module');
+        // Check is Userland Theme has a Module Icon Override
+        if (file_exists('etc/styles/' . ui_template::GetUserTemplate() . '/images/'.$mod_folder.'/assets/icon.png')) {
+            $module_icon = 'etc/styles/' . ui_template::GetUserTemplate() . '/images/'.$mod_folder.'/assets/icon.png';
+        } else {
+            $module_icon = 'modules/' . $mod_folder . '/assets/icon.png';
+        }
         return $module_icon;
     }
 

--- a/modules/usage_viewer/code/controller.ext.php
+++ b/modules/usage_viewer/code/controller.ext.php
@@ -273,10 +273,16 @@ class module_controller
         return ui_language::translate(ui_module::GetModuleName());
     }
 
-    static function getModuleIcon()
-    {
+    static function getModuleIcon() {
         global $controller;
-        return 'modules/' . $controller->GetControllerRequest('URL', 'module') . '/assets/icon.png';
+        $mod_folder = $controller->GetControllerRequest('URL', 'module');
+        // Check is Userland Theme has a Module Icon Override
+        if (file_exists('etc/styles/' . ui_template::GetUserTemplate() . '/images/'.$mod_folder.'/assets/icon.png')) {
+            $module_icon = 'etc/styles/' . ui_template::GetUserTemplate() . '/images/'.$mod_folder.'/assets/icon.png';
+        } else {
+            $module_icon = 'modules/' . $mod_folder . '/assets/icon.png';
+        }
+        return $module_icon;
     }
 
 }

--- a/modules/webalizer_stats/code/controller.ext.php
+++ b/modules/webalizer_stats/code/controller.ext.php
@@ -87,7 +87,7 @@ class module_controller {
     }
 
     static function getInit() {
-        
+
     }
 
     static function getDescription() {
@@ -101,7 +101,13 @@ class module_controller {
 
     static function getModuleIcon() {
         global $controller;
-        $module_icon = "/modules/" . $controller->GetControllerRequest('URL', 'module') . "/assets/icon.png";
+        $mod_folder = $controller->GetControllerRequest('URL', 'module');
+        // Check is Userland Theme has a Module Icon Override
+        if (file_exists('etc/styles/' . ui_template::GetUserTemplate() . '/images/'.$mod_folder.'/assets/icon.png')) {
+            $module_icon = 'etc/styles/' . ui_template::GetUserTemplate() . '/images/'.$mod_folder.'/assets/icon.png';
+        } else {
+            $module_icon = 'modules/' . $mod_folder . '/assets/icon.png';
+        }
         return $module_icon;
     }
 

--- a/modules/webmail/code/controller.ext.php
+++ b/modules/webmail/code/controller.ext.php
@@ -3,7 +3,7 @@
 /**
  *
  * ZPanel - A Cross-Platform Open-Source Web Hosting Control panel.
- * 
+ *
  * @package ZPanel
  * @version $Id$
  * @author Bobby Allen - ballen@zpanelcp.com
@@ -43,7 +43,13 @@ class module_controller {
 
     static function getModuleIcon() {
         global $controller;
-        $module_icon = "modules/" . $controller->GetControllerRequest('URL', 'module') . "/assets/icon.png";
+        $mod_folder = $controller->GetControllerRequest('URL', 'module');
+        // Check is Userland Theme has a Module Icon Override
+        if (file_exists('etc/styles/' . ui_template::GetUserTemplate() . '/images/'.$mod_folder.'/assets/icon.png')) {
+            $module_icon = 'etc/styles/' . ui_template::GetUserTemplate() . '/images/'.$mod_folder.'/assets/icon.png';
+        } else {
+            $module_icon = 'modules/' . $mod_folder . '/assets/icon.png';
+        }
         return $module_icon;
     }
 

--- a/modules/zpanelconfig/code/controller.ext.php
+++ b/modules/zpanelconfig/code/controller.ext.php
@@ -3,7 +3,7 @@
 /**
  *
  * ZPanel - A Cross-Platform Open-Source Web Hosting Control panel.
- * 
+ *
  * @package ZPanel
  * @version $Id$
  * @author Bobby Allen - ballen@zpanelcp.com
@@ -150,7 +150,7 @@ class module_controller {
             $sql->execute();
         }
         if (isset($formvars['inRunDaemon'])) {
-            
+
         }
         self::$ok = true;
     }
@@ -178,7 +178,13 @@ class module_controller {
 
     static function getModuleIcon() {
         global $controller;
-        $module_icon = "./modules/" . $controller->GetControllerRequest('URL', 'module') . "/assets/icon.png";
+        $mod_folder = $controller->GetControllerRequest('URL', 'module');
+        // Check is Userland Theme has a Module Icon Override
+        if (file_exists('etc/styles/' . ui_template::GetUserTemplate() . '/images/'.$mod_folder.'/assets/icon.png')) {
+            $module_icon = 'etc/styles/' . ui_template::GetUserTemplate() . '/images/'.$mod_folder.'/assets/icon.png';
+        } else {
+            $module_icon = 'modules/' . $mod_folder . '/assets/icon.png';
+        }
         return $module_icon;
     }
 


### PR DESCRIPTION
Fixed Bug #595 (http://bugs.zpanelcp.com/view.php?id=595) Module pages use a different icon than there default icon on the dashboard!

Prior to this update on the DNS module worked correctly, this updates the `getModuleIcon()` function of all the module controllers
