### PR TITLE
missplitting $homedirectory_to_use

### DIFF
--- a/modules/ftp_management/code/proftpd.php
+++ b/modules/ftp_management/code/proftpd.php
@@ -36,7 +36,7 @@ try {
 
 // Included after acount has been created
 if (!fs_director::CheckForEmptyValue(self::$create)) {
-    $homedir = ctrl_options::GetSystemOption('hosted_dir') . $currentuser['username'] . $homedirectoy_to_use . "";
+    $homedir = ctrl_options::GetSystemOption('hosted_dir') . $currentuser['username'] . $homedirectory_to_use . "";
     $sql = $ftp_db->prepare("INSERT INTO ftpquotalimits (name, quota_type, per_session, limit_type, bytes_in_avail, bytes_out_avail, bytes_xfer_avail, files_in_avail, files_out_avail, files_xfer_avail) VALUES (:username, 'user', 'true', 'hard', 0, 0, 0, 0, 0, 0);");
     $sql->bindParam(':username', $username);
     $sql->execute();


### PR DESCRIPTION
FTP management not working as excepted, when you create a user and pointe to a specifique folder, it shows you in FTP client the root dir (public_html).
