### PR TITLE
Fixed sidebar cursor

### DIFF
--- a/etc/styles/zpanelx/css/default.css
+++ b/etc/styles/zpanelx/css/default.css
@@ -682,7 +682,7 @@ li.highlight {
 #menu-sidebar .heading:hover{
     /*background: #669933;*/
     /*background: #3e3e3e;*/
-    cursor: s-resize;
+    cursor: pointer;
 }
 
 #menu-sidebar ul li a{


### PR DESCRIPTION
"*-resize" cursor styles connotate resizing functionality and indicate that a click & drag motion is required by the users. For the sidebar, this is an incorrect cursor type. Because the appropriate interaction is a simple click, the "pointer" cursor is the correct cursor. That collapse/expand functionality is indicated via the +/- icon (right side) on hover.
