### PR TITLE
Fixed wrong sql cause reseller cannot shadow to there client.

### DIFF
--- a/inc/init.inc.php
+++ b/inc/init.inc.php
@@ -27,7 +27,7 @@ if (isset($_GET['logout'])) {
 
 if (isset($_GET['returnsession'])) {
     if (isset($_SESSION['ruid'])) {
-        ctrl_auth::SetUserSession($_SESSION['ruid']);
+        ctrl_auth::SetUserSession($_SESSION['ruid'], runtime_sessionsecurity::getSessionSecurityEnabled());
         $_SESSION['ruid'] = null;
     }
     header("location: ./");

--- a/modules/shadowing/code/controller.ext.php
+++ b/modules/shadowing/code/controller.ext.php
@@ -80,7 +80,7 @@ class module_controller {
             $sql = "SELECT * FROM x_accounts WHERE ac_deleted_ts IS NULL ORDER BY ac_user_vc";
             $numrows = $zdbh->prepare($sql);          
         } else {
-            $sql = "SELECT COUNT(*) FROM x_accounts WHERE ac_reseller_fk = :userid AND ac_deleted_ts IS NULL";
+            $sql = "SELECT * FROM x_accounts WHERE ac_reseller_fk = :userid AND ac_deleted_ts IS NULL";
             $numrows = $zdbh->prepare($sql);
             $numrows->bindParam(':userid', $currentuser['userid']);            
         }

--- a/modules/shadowing/code/controller.ext.php
+++ b/modules/shadowing/code/controller.ext.php
@@ -98,7 +98,7 @@ class module_controller {
                     if (!fs_director::CheckForEmptyValue($controller->GetControllerRequest('FORM', 'inShadow_' . $rowclients['ac_id_pk']))) {
                         ctrl_auth::KillCookies();
                         ctrl_auth::SetSession('ruid', $currentuser['userid']);
-                        ctrl_auth::SetUserSession($rowclients['ac_id_pk']);
+                        ctrl_auth::SetUserSession($rowclients['ac_id_pk'], runtime_sessionsecurity::getSessionSecurityEnabled());
                         header("location: /");
                         exit;
                     }


### PR DESCRIPTION
My clients told me they can't shadow to there sub-client and I saw this error when they done that.

```
[Sun Dec 29 19:12:47 2013] [error] [client 168.63.240.195] PHP Notice:  Undefined index: ac_id_pk in /etc/zpanel/panel/modules/shadowing/code/controller.ext.php on line 98, referer: http://***/?module=shadowing
```

I changed the sql which solved the issue but got another two errors.

```
[Sun Dec 29 19:26:24 2013] [error] [client 168.63.240.195] PHP Warning:  Missing argument 2 for ctrl_auth::SetUserSession(), called in /etc/zpanel/panel/modules/shadowing/code/controller.ext.php on line 102 and defined in /etc/zpanel/panel/dryden/ctrl/auth.class.php on line 57, referer: http://***/?module=shadowing
[Sun Dec 29 19:26:24 2013] [error] [client 168.63.240.195] PHP Notice:  Undefined variable: sessionSecuirty in /etc/zpanel/panel/dryden/ctrl/auth.class.php on line 61, referer: http://***/?module=shadowing
```

Not sure is it cause another problem but shadow is working fine on my server now.
