### PR TITLE
Added missing meta tag

### DIFF
--- a/etc/styles/zpanelx/master.ztml
+++ b/etc/styles/zpanelx/master.ztml
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>ZPanel &gt; <# ui_tpl_username #> - <# ui_tpl_domainname #></title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Web Hosting Control Panel">


### PR DESCRIPTION
Ensures IE doesn't go into compatibility mode. This is already applied to login page but was missed here.
