### PR TITLE
Fixed PhpSysInfo Vulnerability

### DIFF
--- a/etc/apps/phpsysinfo/xml.php
+++ b/etc/apps/phpsysinfo/xml.php
@@ -28,6 +28,11 @@ define('APP_ROOT', dirname(__FILE__));
  */
 define('PSI_INTERNAL_XML', true);
 
+session_start();
+if (!isset($_SESSION['zpuid'])) {
+    die("<h1>Unathorised request!</h1><p>You must be logged in before you are able to view the server resource information.</p>");
+}
+
 require_once APP_ROOT.'/includes/autoloader.inc.php';
 
 // check what xml part should be generated


### PR DESCRIPTION
Fixed the disclosure vulnerability mentioned in http://bugs.zpanelcp.com/view.php?id=704

I haven't tested if this fixes the XSS vulnerability (I doubt it has) also mentioned in the bug report though.

The added code is the same as in index.php - it stops users that are not logged into ZPanel accessing system information.
