### PR TITLE
Fixed font alias issue in Safari

### DIFF
--- a/etc/styles/zpanelx/global-css/bootstrap.css
+++ b/etc/styles/zpanelx/global-css/bootstrap.css
@@ -3684,6 +3684,7 @@ button.close {
 
 .navbar-inverse .navbar-nav > li > a {
   color: #999999;
+  -webkit-font-smoothing: subpixel-antialiased;
 }
 
 .navbar-inverse .navbar-nav > li > a:hover,


### PR DESCRIPTION
In Safari (7.0.2 on Mavericks), clicking on one of the menu items causes the font in in the navbar to get thinner. By hard-setting the antialiasing method to `subpixel-antialiased` (Safari's default) this fixes that problem.

The problem:  
![](http://cl.ly/UCz6/problem.gif)

Fixed:  
![](http://cl.ly/UDng/fixed.gif)
