### PR TITLE
Add missing icons in navbar for installed modules

### DIFF
--- a/dryden/ui/tpl/modulelist2column.class.php
+++ b/dryden/ui/tpl/modulelist2column.class.php
@@ -50,7 +50,7 @@ class ui_tpl_modulelist2column {
 
                         $line .= '              <li>';
                         $line .= '                      <a href="?module=' . $mod['mo_folder_vc'] . '" title="<: ' . $mod['mo_desc_tx'] . ' :>">';
-                        $line .= '<img src="' .$icon. '" border="0">';
+                        $line .= '<img src="' .$icon. '">';
                         $line .= '                      </a>';
                         $line .= '                      <br />';
                         $line .= '                      <a href="?module=' . $mod['mo_folder_vc'] . '"><: ' . $cleanname . ' :></a>';

--- a/dryden/ui/tpl/modulelistznavbar.class.php
+++ b/dryden/ui/tpl/modulelistznavbar.class.php
@@ -71,7 +71,11 @@ class ui_tpl_modulelistznavbar
                     } else {
                         $line .= '<li>';
                     }
-                    $line .= '<a href="?module=' . $mod['mo_folder_vc'] . '"><i class="icon-' . $class_name . '"></i> <: ' . $mod['mo_name_vc'] . ' :></a></li>';
+                    if ($mod['mo_installed_ts'] != 0) {
+                        $line .= '<a href="?module=' . $mod['mo_folder_vc'] . '"><i class="icon-' . $class_name . '"><img src="/modules/' . $mod['mo_folder_vc'] . '/assets/icon.png" height="16px" width="16px"></i> <: ' . $mod['mo_name_vc'] . ' :></a></li>';
+                    } else {
+                        $line .= '<a href="?module=' . $mod['mo_folder_vc'] . '"><i class="icon-' . $class_name . '"></i> <: ' . $mod['mo_name_vc'] . ' :></a></li>';
+                    }
                 }
 // If Account tab, show Logout Menu Item
                 if ($shortName == '<: Account :>') {

--- a/etc/styles/zpanelx/css/default.css
+++ b/etc/styles/zpanelx/css/default.css
@@ -99,12 +99,17 @@ li.highlight {
 }
 .sortable.grid li ul li {
     float: left;
-    margin: 0 11px 0 11px;
+    margin: 5px 11px 5px 11px;
     list-style: none;
     text-align: center;
     width: 40px;
     clear: none;
     line-height: 15px;
+}
+.sortable.grid li ul li img {
+    height: 40px;
+    width: 40px;
+    border: 0;
 }
 
 


### PR DESCRIPTION
This fixes #154 

Currently if you install a module there's not the associated class within the css to provide a nav icon for it (core modules get the clean sexy icons only). The main module layout handles this fine and pulls from the module assets. We're just going to make the navbar title grab an icon from the assets for aftermarket modules as well.

<hr>

<p align="center">
<b>Before This Patch</b>
<br>
<img src="http://i.imgur.com/Mky91P1.png">
</p>

<hr>

<p align="center">
<b>After This Patch</b>
<br>
<img src="http://i.imgur.com/hITHNi6.png">
</p>

<hr>

Furthermore, as I'm a big fan of the sexy greyscale color theme I almost went there.... What I mean is that if you want to, just toss this in what is now line 75 after the width declaration....

`style="filter: grayscale(100%); -webkit-filter: grayscale(100%); -moz-filter: grayscale(100%); -ms-filter: grayscale(100%); -o-filter: grayscale(100%); filter: gray;"`

and you'll get this...

<hr>

<p align="center">
<b>Greyscale</b>
<br>
<img src="http://i.imgur.com/zkW9iqc.png">
</p>

<hr>

I didn't include this because it's not really theme friendly as the rest of the icons you'd be able to control easily (from the accessible css file) but these you'd have to bust out nasty `!important` declarations over all of em. Again, just my train of thought for others, I'll personally mod it to greyscale myself as I dig the default design. @bobsta63 if you like the greyscale for core uniformity let me know and I'll resubmit with it in there.

Also seeing another issue with custom modules, we'll just fix this now...

Commit 132ad7244ef1c848547d032e481109ee44d3b578 and Commit 5318379719c4b5b6e6aaadcf137a890c255b144e

<p align="center">
<b>Turn this..</b>
<br>
<img src="http://i.imgur.com/3iC1SzN.png">
</p>


<p align="center">
<b>Into this...</b>
<br>
<img src="http://i.imgur.com/5iV49gS.png">
</p>


Also note that the greyscale hack can be applied to the new class @ commit 132ad7244ef1c848547d032e481109ee44d3b578
