### PR TITLE
Add missing icons in navbar for installed modules

### DIFF
--- a/dryden/ui/tpl/modulelistznavbar.class.php
+++ b/dryden/ui/tpl/modulelistznavbar.class.php
@@ -71,7 +71,12 @@ class ui_tpl_modulelistznavbar
                     } else {
                         $line .= '<li>';
                     }
-                    $line .= '<a href="?module=' . $mod['mo_folder_vc'] . '"><i class="icon-' . $class_name . '"></i> <: ' . $mod['mo_name_vc'] . ' :></a></li>';
+                    if ($mod['mo_installed_ts'] != 0) {
+                        $line .= '<a href="?module=' . $mod['mo_folder_vc'] . '"><i class="icon-' . $class_name . ' greyscale"><img src="/modules/' . $mod['mo_folder_vc'] . '/assets/icon.png" height="16px" width="16px"></i> <: ' . $mod['mo_name_vc'] . ' :></a></li>';
+                    } else {
+                        $line .= '<a href="?module=' . $mod['mo_folder_vc'] . '"><i class="icon-' . $class_name . '"></i> <: ' . $mod['mo_name_vc'] . ' :></a></li>';
+                    }
+                    
                 }
 // If Account tab, show Logout Menu Item
                 if ($shortName == '<: Account :>') {

--- a/dryden/ui/tpl/modulelistzsidebar.class.php
+++ b/dryden/ui/tpl/modulelistzsidebar.class.php
@@ -17,17 +17,20 @@ class ui_tpl_modulelistzsidebar {
         $modcats = ui_moduleloader::GetModuleCats();
 
         foreach ($modcats as $modcat) {
-             $mods = ui_moduleloader::GetModuleList($modcat['mc_id_pk'], 'modadmin');
+             	$mods = ui_moduleloader::GetModuleList($modcat['mc_id_pk'], 'modadmin');
 
-			$line .= '<li>';
-			$line .= '<div class="heading">' .$modcat['mc_name_vc']. ' <span class="open">+</span></div>';
-            $line .= '<ul>';
-            foreach ($mods as $mod) {
+		$line .= '<li>';
+		$line .= '<div class="heading">' .$modcat['mc_name_vc']. ' <span class="open">+</span></div>';
+            	$line .= '<ul>';
+            	foreach ($mods as $mod) {
 
                 $class_name = str_replace(array(' ', '_'), '-', strtolower($mod['mo_folder_vc']));
-
-                $line .= '<li>';
-	    $line .= '<a href="?module=' . $mod['mo_folder_vc']. '"><i class="icon-'.$class_name.'"></i> ';
+		$line .= '<li>';
+		if ($mod['mo_installed_ts'] != 0) {
+			$line .= '<a href="?module=' . $mod['mo_folder_vc']. '"><i class="icon-' . $class_name . ' greyscale transparent"><img src="/modules/' . $mod['mo_folder_vc'] . '/assets/icon.png" height="16px" width="16px"></i> ';
+		} else {
+			$line .= '<a href="?module=' . $mod['mo_folder_vc']. '"><i class="icon-'.$class_name.'"></i> ';
+		}
                 $line .= '<: '.$mod['mo_name_vc'].' :>';
                 $line .= '</a>';
                 $line .= '</li>';

--- a/etc/styles/zpanelx/css/default.css
+++ b/etc/styles/zpanelx/css/default.css
@@ -781,6 +781,11 @@ li.highlight {
     -o-filter: grayscale(100%);
     filter: gray;
 }
+.transparent {
+    zoom: 1;
+    filter: alpha(opacity=50);
+    opacity: 0.5;
+}
 
 /*
 .icon-password-assistant:before

--- a/etc/styles/zpanelx/css/default.css
+++ b/etc/styles/zpanelx/css/default.css
@@ -773,6 +773,14 @@ li.highlight {
 .i-code {
     display: none;
 }
+.greyscale {
+    filter: grayscale(100%);
+    -webkit-filter: grayscale(100%);
+    -moz-filter: grayscale(100%);
+    -ms-filter: grayscale(100%);
+    -o-filter: grayscale(100%);
+    filter: gray;
+}
 
 /*
 .icon-password-assistant:before

--- a/etc/styles/zpanelx/css/default.css
+++ b/etc/styles/zpanelx/css/default.css
@@ -78,7 +78,6 @@ li.highlight {
     overflow: hidden;
 }
 .sortable.grid li {
-    float: left;
     /*width: 395px;*/
     height: auto;
     /*width: 100%;*/
@@ -98,13 +97,24 @@ li.highlight {
     margin: 0 0 0 5px;
 }
 .sortable.grid li ul li {
-    float: left;
-    margin: 0 11px 0 11px;
+    display: inline-block;
+    margin: 0 11px 5px 11px;
     list-style: none;
     text-align: center;
-    width: 40px;
+    width: auto;
+    max-width: 60px;
     clear: none;
     line-height: 15px;
+    vertical-align: text-top;
+}
+.sortable.grid li ul li img {
+    height: 40px;
+    filter: grayscale(100%);
+    -webkit-filter: grayscale(100%);
+    -moz-filter: grayscale(100%);
+    -ms-filter: grayscale(100%);
+    -o-filter: grayscale(100%);
+    filter: gray;
 }
 
 
@@ -137,6 +147,7 @@ li.highlight {
 
 /* Modules homepage */
 .module-box {
+    float: left;
     padding: 0px;
     margin-bottom: 26px;
 }


### PR DESCRIPTION
Currently if you install a module there's not the associated class within the css to provide a nav icon for it (core modules get the clean sexy icons only). The main module layout handles this fine and pulls from the module assets. We're just going to make the navbar title grab an icon from the assets for aftermarket modules as well.

<hr>

<p align="center">
<b>Before This Patch</b>
<br>
<img src="http://i.imgur.com/Mky91P1.png">
</p>

<hr>

<p align="center">
<b>After This Patch</b>
<br>
<img src="http://i.imgur.com/zkW9iqc.png">
</p>


Side Note: IE10-11 dropped filters support among other odd changes. This can be fixed via javascript but at the cost of a bit of overhead. A workaround is detailed [here](http://www.majas-lapu-izstrade.lv/cross-browser-grayscale-image-example-using-css3-js/) and the unique target-able classname will help with this.
