### PR TITLE
Bug fix: Not retrieving correct salt for username with deleted accounts

### DIFF
--- a/inc/init.inc.php
+++ b/inc/init.inc.php
@@ -103,7 +103,7 @@ if (isset($_POST['inUsername'])) {
     $rememberdetails = isset($_POST['inRemember']);
     $inSessionSecuirty = isset($_POST['inSessionSecuirty']);
 
-    $sql = $zdbh->prepare("SELECT ac_passsalt_vc FROM x_accounts WHERE ac_user_vc = :username");
+    $sql = $zdbh->prepare("SELECT ac_passsalt_vc FROM x_accounts WHERE ac_user_vc = :username AND ac_deleted_ts IS NULL");
     $sql->bindParam(':username', $_POST['inUsername']);
     $sql->execute();
     $result = $sql->fetch();


### PR DESCRIPTION
When there are multiple usernames in the x_accounts table, the 1st entry is always selected with the current query. Query has been adjusted to select the record that has not been deleted by adding " AND ac_deleted_ts IS NULL" to the query.
