### PR TITLE
Allowed Plus sign (+) in email

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /log.txt
 /cnf/db.php
 /.vagrant
+.idea

--- a/modules/manage_clients/code/controller.ext.php
+++ b/modules/manage_clients/code/controller.ext.php
@@ -674,7 +674,7 @@ class module_controller extends ctrl_module
 
     static function IsValidEmail($email)
     {
-        if (!preg_match('/^[a-z0-9]+([_\\.-][a-z0-9]+)*@([a-z0-9]+([\.-][a-z0-9]+)*)+\\.[a-z]{2,}$/i', $email)) {
+        if (!preg_match('/^[a-z0-9]+([_\+\\.-][a-z0-9]+)*@([a-z0-9]+([\.-][a-z0-9]+)*)+\\.[a-z]{2,}$/i', $email)) {
             return false;
         }
         return true;

--- a/modules/manage_clients/code/controller.ext.php
+++ b/modules/manage_clients/code/controller.ext.php
@@ -1006,6 +1006,9 @@ class module_controller extends ctrl_module
     static function getDefaultEmailBody()
     {
         global $controller;
+        if ($emailBodyFromSetting = ctrl_options::GetSystemOption('defaultEmailBody')){
+            return $emailBodyFromSetting;
+        }
         return self::DefaultEmailBody();
     }
 

--- a/modules/mysql_users/code/controller.ext.php
+++ b/modules/mysql_users/code/controller.ext.php
@@ -514,7 +514,7 @@ class module_controller extends ctrl_module
 
     static function IsValidUserName($username)
     {
-        if (!preg_match('/^[a-z\d][a-z\d-]{0,62}$/i', $username) || preg_match('/-$/', $username)) {
+        if (!preg_match('/^[a-z\d][a-z\d-\_]{0,62}$/i', $username) || preg_match('/-$/', $username)) {
             return false;
         } else {
             if (strlen($username) < 17) {


### PR DESCRIPTION
Plus is valid in emails & exclusively used in gmail alias. Very useful
if you want to create different users with your own email address

In addition added .idea (phpstorm working environment files) in
.gitignore
