### PR TITLE
Fixed runtimeException in launchbackup

### DIFF
--- a/modules/backupmgr/code/launchbackup.php
+++ b/modules/backupmgr/code/launchbackup.php
@@ -76,7 +76,9 @@ if ($_SESSION['zpuid'] == $userid) {
 function dirSize($directory) {
     $size = 0;
     foreach (new RecursiveIteratorIterator(new RecursiveDirectoryIterator($directory)) as $file) {
-        $size+=$file->getSize();
+        try {
+            $size+=$file->getSize();
+        } catch (RuntimeException $e) { }
     }
     return $size;
 }


### PR DESCRIPTION
In reference to this thread on the forums: http://forums.zpanelcp.com/Thread-SOLVED-Launch-Backup-No-Longer-Working?pid=85265

I ran into an issue where launching a manual backup suddenly stopped working (wouldn't calculate the current public directory size) after uploading lots of site files. Looking into it further I found that $file->getSize would throw a RuntimeException if it didn't have permission to read the size of a file.
