### PR TITLE
Update controller.ext.php

### DIFF
--- a/modules/dns_admin/code/controller.ext.php
+++ b/modules/dns_admin/code/controller.ext.php
@@ -989,18 +989,18 @@ class module_controller extends ctrl_module
                                                             'NS',
                                                             '@',
                                                             172800,
-                                                            :vh_name_vc2,
+                                                            :ns1,
                                                             NULL,
                                                             NULL,
                                                             NULL,
                                                             :time)");
         $sql->bindParam(':userID', $userID);
         $Domain = 'ns1.' . $domainName['vh_name_vc'];
-        $sql->bindParam(':vh_name_vc', $Domain);
+        $sql->bindParam(':ns1', $Domain);
         $sql->bindParam(':domainID', $domainID);
         $time = time();
         $sql->bindParam(':time', $time);
-        $sql->bindParam(':vh_name_vc2', $domainName['vh_name_vc']);
+        $sql->bindParam(':vh_name_vc', $domainName['vh_name_vc']);
         $sql->execute();
         $sql = $zdbh->prepare("INSERT INTO x_dns (dn_acc_fk,
                                                             dn_name_vc,
@@ -1032,6 +1032,10 @@ class module_controller extends ctrl_module
         $sql->bindParam(':time', $time);
         $sql->bindParam(':vh_name_vc', $domainName['vh_name_vc']);
         $sql->execute();
+        
+        self::TriggerDNSUpdate($domainID);
+
+        
         return;
     }
 


### PR DESCRIPTION
There is a problem in the original function when create defaults nameservers first of all does not create ns1.example.com only creates example.com and does not write the bind config files.

I had that problem and modifying this file solved that problem. Tested on my webserver at danvaly.ro
