### PR TITLE
EASY Fix: Enable Wildcard Subdomains w/ Just 2 Characters

### DIFF
--- a/modules/sub_domains/code/controller.ext.php
+++ b/modules/sub_domains/code/controller.ext.php
@@ -248,7 +248,7 @@ class module_controller extends ctrl_module
         if (stristr($a, '.')) {
             $part = explode(".", $a);
             foreach ($part as $check) {
-                if (!preg_match('/^[a-z\d][a-z\d-]{0,62}$/i', $check) || preg_match('/-$/', $check)) {
+                if (!preg_match('/^[\*a-z\d][a-z\d-]{0,62}$/i', $check) || preg_match('/-$/', $check)) {
                     return false;
                 }
             }

--- a/modules/sub_domains/code/controller.ext.php
+++ b/modules/sub_domains/code/controller.ext.php
@@ -243,19 +243,25 @@ class module_controller extends ctrl_module
         return in_array($error, $errordocs);
     }
 
-    static function IsValidDomainName($a)
+static function IsValidDomainName($a)
     {
-        if (stristr($a, '.')) {
-            $part = explode(".", $a);
-            foreach ($part as $check) {
-                if (!preg_match('/^[\*a-z\d][a-z\d-]{0,62}$/i', $check) || preg_match('/-$/', $check)) {
-                    return false;
-                }
+    $currentuser = ctrl_users::GetUserDetail();
+  
+    if (stristr($a, '.')) {
+        $part = explode(".", $a);
+        foreach ($part as $check) {
+            if (($currentuser['subdomainquota'] < 0) && (preg_match('/^[\*a-z\d][a-z\d-]{0,62}$/i', $check)) && (!preg_match('/-$/', $check))) {
+            	return true;
             }
-        } else {
-            return false;
+            elseif (($currentuser['subdomainquota'] > 0) && (preg_match('/^[a-z\d][a-z\d-]{0,62}$/i', $check)) && (!preg_match('/-$/', $check))) {
+            	return true;
+            } else {
+            	return false;
+            }
         }
-        return true;
+    } else {
+    	return false;
+    	}                
     }
 
     static function IsValidEmail($email)


### PR DESCRIPTION
At or around line 251, in the 'static function IsValidDomainName($a)', simply add '\*' into the first group so that the form will also accept an asterisk along with numbers, letters and hyphens within a subdomain name. When the daemon/cron runs its process -everything falls into place. In other words - it will work just like adding a subdomain using cPanel.
