### PR TITLE
getDescription function added

### DIFF
--- a/modules/webalizer_stats/code/controller.ext.php
+++ b/modules/webalizer_stats/code/controller.ext.php
@@ -92,5 +92,12 @@ class module_controller extends ctrl_module
     {
         
     }
+    
+    /**
+    * STANDARD MODULE STATIC METHODS!
+    */
+    static function getDescription() {
+        return ui_module::GetModuleDescription();
+    }
 
 }


### PR DESCRIPTION
Webalizer module is failing to load without getDescription static function as line 210 of panel/dryden/uitemplateparser.class.php calls the static function.
